### PR TITLE
Develop

### DIFF
--- a/run_mtlog_mockup.sh
+++ b/run_mtlog_mockup.sh
@@ -1,1 +1,1 @@
-cargo run --bin generate_mt_log_large_files -- 10000000
+cargo run --bin generate_mt_log_large_files -- 1000000

--- a/src/parallel_merge/mod.rs
+++ b/src/parallel_merge/mod.rs
@@ -6,7 +6,7 @@ use num_format::{Locale, ToFormattedString};
 use rayon::prelude::*;
 use std::cmp::Ordering;
 use std::fs::File;
-use std::io::{BufReader, BufWriter};
+use std::io::{BufRead, BufWriter, Write, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -289,19 +289,23 @@ pub fn parallel_split_file_to_chunks(
             debug!("[SPLIT] Chunk {} last 3 rows: {:?}", i, &records.iter().rev().take(3).collect::<Vec<_>>());
         }
         let file_stem = file_path.file_stem().and_then(|s| s.to_str()).unwrap_or("input");
-        let chunk_path = temp_dir.path().join(format!("chunk_parallel_{}_{}.csv", file_stem, i));
-        let write_start = Instant::now();
-        let mut wtr = WriterBuilder::new().has_headers(true).from_path(&chunk_path)?;
-        wtr.write_record(headers)?;
-        for rec in &records {
-            wtr.write_record(rec)?;
+        let tmp = tempfile::NamedTempFile::new()?;
+        {
+            let mut writer = WriterBuilder::new()
+                .has_headers(false)
+                .from_writer(BufWriter::with_capacity(8 * 1024 * 1024, tmp.as_file()));
+            writer.write_record(headers)?;
+            for rec in &records {
+                writer.write_record(rec)?;
+            }
+            writer.flush()?;
         }
-        wtr.flush()?;
-        let write_elapsed = write_start.elapsed();
+        let chunk_path = temp_dir.path().join(format!("chunk_parallel_{}_{}.csv", file_stem, i));
+        tmp.persist(&chunk_path)?;
         let chunk_elapsed = chunk_start_time.elapsed();
         info!(
             "[split] Chunk {}/{} | Records: {} | Path: {:?} | Sort: {:.2?} | Write: {:.2?} | Total: {:.2?}",
-            i + 1, fmtnum(chunk_count), fmtnum(records.len()), chunk_path, sort_elapsed, write_elapsed, chunk_elapsed
+            i + 1, fmtnum(chunk_count), fmtnum(records.len()), chunk_path, sort_elapsed, chunk_elapsed - sort_elapsed, chunk_elapsed
         );
         Ok(chunk_path)
     }).collect();
@@ -334,7 +338,6 @@ pub fn parallel_split_file_to_chunks(
 /// * `Result<()>` - Returns `Ok(())` if the sorting operation completes successfully, or an error if an issue occurs during the process.
 ///
 /// # Functionality
-///
 /// 1. **Input Validation:**
 ///     - Checks if input files are provided; returns an error if the list is empty.
 ///     - Validates the headers across all input files to ensure consistency.
@@ -446,289 +449,11 @@ pub fn parallel_merge_sort(
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MTLogSortType {
-    Date,
-    Time,
-    Num,
-    Str,
-}
+mod mtlog;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MTLogSortColumn {
-    pub index: usize,
-    pub col_type: MTLogSortType,
-}
-
-/// Performs a parallel merge sort on multiple MT log files.
-///
-/// This function reads multiple input files, splits the data into chunks, 
-/// sorts the chunks in parallel, and then performs a k-way merge to create
-/// a single sorted output file. It is designed for large-scale log processing 
-/// and can efficiently handle millions of records.
-///
-/// # Parameters
-/// - `input_paths`: A slice of `PathBuf` representing the paths to the input files to be merged.
-/// - `output_path`: The path to the output file where the merged and sorted logs will be written.
-/// - `sort_columns`: A slice of `MTLogSortColumn` which defines the sort key(s) and order for the records.
-///
-/// # Environment Variables
-/// - `CHUNK_RECORDS` (optional): Specifies the number of records per chunk for parallel processing.
-///   Defaults to 1,000,000 if unset.
-///
-/// # Process
-/// 1. **Chunk Splitting and Sorting:**
-///     - Reads input files line by line.
-///     - Groups records into chunks based on `CHUNK_RECORDS`.
-///     - Each chunk is sorted based on the `sort_columns` using parallel processing.
-///     - Temporary files are created for each sorted chunk.
-///
-/// 2. **K-Way Merge:**
-///     - Merges all sorted chunks into one sorted output file using a binary heap for efficiency.
-///     - Continuously writes merged records to the output file.
-///
-/// 3. **Logging:**
-///     - Logs progress during chunk creation, sorting, and merging.
-///     - Provides elapsed time and record count statistics for each step.
-///
-/// # Returns
-/// - `Ok(())` if the process completes successfully.
-/// - `Err(anyhow::Error)` if any error occurs during the process, such as I/O failures.
-///
-/// # Errors
-/// Possible errors include:
-/// - Missing or invalid input files in `input_paths`.
-/// - I/O errors when reading from input files, writing to temporary chunk files, or writing the output file.
-/// - Sorting logic errors due to malformed input or incorrect column specifications.
-///
-/// # Example Usage
-/// ```rust
-/// use std::path::PathBuf;
-/// use my_crate::{parallel_merge_sort_mtlog, MTLogSortColumn};
-///
-/// let input_paths = vec![PathBuf::from("log1.txt"), PathBuf::from("log2.txt")];
-/// let output_path = PathBuf::from("merged_log.txt");
-/// let sort_columns = vec![MTLogSortColumn::Timestamp, MTLogSortColumn::Severity];
-///
-/// parallel_merge_sort_mtlog(&input_paths, output_path, &sort_columns).unwrap();
-/// ```
-///
-/// # Performance
-/// - The function uses multithreading and parallel sorting to handle large input efficiently.
-/// - Sorting is performed using `par_sort_unstable`, and the k-way merge is optimized with a binary heap.
-///
-/// # Notes
-/// - Ensure the input files are compatible with the expected format and sorting criteria.
-/// - Temporary files created during the process are automatically removed after merging completes.
-///
-/// # Dependencies
-/// - `rayon`: Used for parallel sorting.
-/// - `tempfile`: Used for creating and managing temporary chunk files.
-/// - `log`: Used for logging the progress of the operation.
-pub fn parallel_merge_sort_mtlog(
-    input_paths: &[PathBuf],
-    output_path: impl AsRef<Path>,
-    sort_columns: &[MTLogSortColumn],
-) -> Result<()> {
-    use std::io::{BufRead, BufReader, BufWriter, Write};
-    use std::fs::File;
-    use std::collections::BinaryHeap;
-    use std::cmp::Ordering;
-    use std::time::Instant;
-    
-    let total_timer = Instant::now();
-    if input_paths.is_empty() {
-        log::warn!("[mtlog] No input files provided for MT log merge");
-        return Err(anyhow::anyhow!("No input files provided"));
-    }
-    log::info!("[mtlog] Starting parallel chunked merge of {} files into {:?}", input_paths.len().to_formatted_string(&Locale::en), output_path.as_ref());
-
-    // 1. Split to sorted chunks in parallel (by number of records)
-    let chunk_records = std::env::var("CHUNK_RECORDS").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(1_000_000);
-    log::info!("[mtlog] Chunk size: {} records", chunk_records.to_formatted_string(&Locale::en));
-    let mut chunk_files = Vec::new();
-    let mut all_lines = Vec::new();
-    let mut cur_records = 0;
-    let chunk_timer = Instant::now();
-    let mut total_records: usize = 0;
-    for path in input_paths {
-        log::info!("[mtlog] Reading input file: {}", path.display());
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        for line in reader.lines() {
-            let line = line?;
-            cur_records += 1;
-            total_records += 1;
-            all_lines.push(line);
-            if cur_records >= chunk_records {
-                let mut chunk = std::mem::take(&mut all_lines);
-                cur_records = 0;
-                let sort_timer = Instant::now();
-                chunk.par_sort_unstable_by(|a, b| compare_mtlog_by_columns(a, b, sort_columns));
-                log::info!("[mtlog] Sorted chunk of {} records in {:.2?}", chunk.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
-                let mut tmp = tempfile::NamedTempFile::new()?;
-                for l in &chunk { writeln!(tmp, "{}", l)?; }
-                chunk_files.push(tmp.into_temp_path());
-                log::info!("[mtlog] Wrote sorted chunk file #{} ({} records)", chunk_files.len().to_formatted_string(&Locale::en), chunk.len().to_formatted_string(&Locale::en));
-            }
-        }
-    }
-    if !all_lines.is_empty() {
-        let sort_timer = Instant::now();
-        all_lines.par_sort_unstable_by(|a, b| compare_mtlog_by_columns(a, b, sort_columns));
-        log::info!("[mtlog] Sorted final chunk of {} records in {:.2?}", all_lines.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
-        let mut tmp = tempfile::NamedTempFile::new()?;
-        for l in &all_lines { writeln!(tmp, "{}", l)?; }
-        chunk_files.push(tmp.into_temp_path());
-        log::info!("[mtlog] Wrote sorted chunk file #{} ({} records)", chunk_files.len().to_formatted_string(&Locale::en), all_lines.len().to_formatted_string(&Locale::en));
-    }
-    log::info!("[mtlog] {} sorted chunk files created in {:.2?}", chunk_files.len().to_formatted_string(&Locale::en), chunk_timer.elapsed());
-    log::info!("[mtlog] Total input records: {}", total_records.to_formatted_string(&Locale::en));
-
-    // 2. K-way merge sorted chunks
-    let merge_timer = Instant::now();
-    let mut writer = BufWriter::new(File::create(output_path.as_ref())?);
-    let mut readers: Vec<_> = chunk_files.iter().map(|p| BufReader::new(File::open(p).unwrap())).collect();
-    let mut heap = BinaryHeap::new();
-    let mut merged_count = 0usize;
-    // Prime heap
-    for (idx, rdr) in readers.iter_mut().enumerate() {
-        let mut buf = String::new();
-        if rdr.read_line(&mut buf)? > 0 {
-            let line = buf.trim_end_matches('\n').to_string();
-            heap.push(MTLogHeapItem { line, idx, sort_columns });
-        }
-    }
-    while let Some(MTLogHeapItem { line, idx, .. }) = heap.pop() {
-        writeln!(writer, "{}", line)?;
-        merged_count += 1;
-        if merged_count % 500_000 == 0 {
-            log::info!("[mtlog] Merged {} records so far...", merged_count.to_formatted_string(&Locale::en));
-        }
-        let rdr = &mut readers[idx];
-        let mut buf = String::new();
-        if rdr.read_line(&mut buf)? > 0 {
-            let next_line = buf.trim_end_matches('\n').to_string();
-            heap.push(MTLogHeapItem { line: next_line, idx, sort_columns });
-        }
-    }
-    writer.flush()?;
-    log::info!("[mtlog] K-way merge complete: {} records merged in {:.2?}", merged_count.to_formatted_string(&Locale::en), merge_timer.elapsed());
-    log::info!("[mtlog] Merge complete: chunked+sorted into {:?} in {:.2?}", output_path.as_ref(), total_timer.elapsed());
-    Ok(())
-}
-
-// Heap item for k-way merge of sorted MT log chunk files
-#[derive(Eq)]
-struct MTLogHeapItem<'a> {
-    line: String,
-    idx: usize,
-    sort_columns: &'a [MTLogSortColumn],
-}
-
-impl<'a> Ord for MTLogHeapItem<'a> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // reverse for min-heap
-        compare_mtlog_by_columns(&other.line, &self.line, self.sort_columns)
-    }
-}
-impl<'a> PartialOrd for MTLogHeapItem<'a> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-impl<'a> PartialEq for MTLogHeapItem<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        self.line == other.line
-    }
-}
-
-/// Compares two MTLog entries represented as strings (`a` and `b`) based on the specified sort columns.
-///
-/// This function iterates through the provided list of `sort_columns` to determine the ordering comparison
-/// between the two MTLog entries. Each `MTLogSortColumn` in the list specifies both the column index 
-/// and the type of sorting to apply (e.g., Date, Time, Num, Str). The order of the `sort_columns` array 
-/// determines the precedence for comparison.
-///
-/// # Arguments
-///
-/// * `a` - A string slice representing the first MTLog entry to compare.
-/// * `b` - A string slice representing the second MTLog entry to compare.
-/// * `sort_columns` - A slice of `MTLogSortColumn` structs specifying which columns and sorting 
-///   types (e.g., Date, Time, Num, Str) to use for comparison.
-///
-/// # Returns
-///
-/// A `std::cmp::Ordering` value:
-/// * `Ordering::Less` if `a` is smaller than `b` based on the sort columns.
-/// * `Ordering::Greater` if `a` is greater than `b` based on the sort columns.
-/// * `Ordering::Equal` if both `a` and `b` are considered equal based on the sort columns.
-///
-/// The function performs the following for each column in `sort_columns`:
-/// 1. Extracts the values for both `a` and `b` using the `get_mtlog_field` function based on the column index.
-/// 2. Compares the extracted values using the rules defined by the column's type:
-///    - `MTLogSortType::Date` or `MTLogSortType::Time`: Lexicographical comparison of the strings.
-///    - `MTLogSortType::Num`: Parsing to `u64` for comparison, with a fallback to `0` if parsing fails.
-///    - `MTLogSortType::Str`: Lexicographical string comparison.
-/// 3. If the comparison result for the current column is not equal, return the comparison result immediately.
-/// 4. If all columns are equal, return `Ordering::Equal`.
-///
-/// # Panics
-///
-/// This function assumes that the `get_mtlog_field` function will provide valid field values
-/// for the specified column indexes and may panic if an invalid index is used or if there's a 
-/// logic issue in `get_mtlog_field`.
-///
-/// # Examples
-///
-/// ```rust
-/// // Example usage of compare_mtlog_by_columns
-/// let mtlog1 = "2023-09-15 12:00:00,INFO,User logged in";
-/// let mtlog2 = "2023-09-15 12:05:00,INFO,User logged out";
-/// let sort_columns = vec![
-///     MTLogSortColumn { index: 0, col_type: MTLogSortType::Date },
-///     MTLogSortColumn { index: 1, col_type: MTLogSortType::Time },
-/// ];
-///
-/// let result = compare_mtlog_by_columns(mtlog1, mtlog2, &sort_columns);
-/// assert_eq!(result, std::cmp::Ordering::Less);
-/// ```
-fn compare_mtlog_by_columns(a: &str, b: &str, sort_columns: &[MTLogSortColumn]) -> std::cmp::Ordering {
-    for col in sort_columns {
-        let (v1, v2) = (get_mtlog_field(a, col.index), get_mtlog_field(b, col.index));
-        let ord = match col.col_type {
-            MTLogSortType::Date | MTLogSortType::Time => v1.cmp(&v2),
-            MTLogSortType::Num => v1.parse::<u64>().unwrap_or(0).cmp(&v2.parse::<u64>().unwrap_or(0)),
-            MTLogSortType::Str => v1.cmp(&v2),
-        };
-        if ord != std::cmp::Ordering::Equal {
-            return ord;
-        }
-    }
-    std::cmp::Ordering::Equal
-}
-
-/// ดึง field จาก fixed-width string ตาม column index
-fn get_mtlog_field(line: &str, col: usize) -> String {
-    // กำหนดตำแหน่งและความยาว field ตาม MTLogRecord (ตัวอย่าง: [start, len])
-    // ต้องตรงกับโครงสร้างจริง!
-    const OFFSETS: &[(usize, usize)] = &[
-        (0,8),    // 0: milog_rec_sys_date
-        (8,6),    // 1: milog_rec_sys_time
-        (14,7),   // 2: milog_rec_taskno
-        (21,4),   // 3: milog_channel_code
-        (25,1),   // 4: milog_rec_rectype
-        (26,8),   // 5: milog_ts_ext_tran_code
-        (34,1),   // 6: milog_tran_type
-        (35,1),   // 7: milog_record_status
-        // ... เพิ่ม field อื่น ๆ ตามต้องการ ...
-    ];
-    if col >= OFFSETS.len() {
-        return String::new();
-    }
-    let (start, len) = OFFSETS[col];
-    line.get(start..start+len).unwrap_or("").trim().to_string()
-}
+pub use mtlog::{
+    MTLogSortType, MTLogSortColumn, parallel_merge_sort_mtlog, merge_k_files_mtlog
+};
 
 /// K-way parallel merge of sorted chunk files into a single sorted output CSV.
 /// - `chunk_paths`: paths to sorted chunk files (with header)
@@ -746,7 +471,7 @@ pub fn parallel_merge_chunks(
     use std::io::BufReader;
 
     if chunk_paths.is_empty() {
-        return Err(anyhow::anyhow!("No chunk files to merge"));
+        return Ok(());
     }
     info!(
         "[merge] Starting k-way merge: {} chunks -> {:?}",
@@ -912,18 +637,20 @@ fn merge_k_files(
     if files.is_empty() {
         return Ok(());
     }
-    let mut readers: Vec<_> = files
-        .iter()
-        .map(|path| {
-            let file = File::open(path)?;
-            let mut rdr = csv::ReaderBuilder::new()
-                .has_headers(true)
-                .from_reader(BufReader::new(file));
-            // Always skip header row for every chunk
-            let _ = rdr.headers();
-            Ok(rdr)
-        })
-        .collect::<Result<Vec<_>>>()?;
+    info!(
+        "[merge] Starting k-way merge: {} chunks -> {:?}",
+        fmtnum(files.len()),
+        output_path
+    );
+    let merge_start = Instant::now();
+
+    // Read headers from the first chunk
+    let first_chunk = &files[0];
+    let mut rdr = ReaderBuilder::new()
+        .has_headers(true)
+        .from_path(first_chunk)?;
+    let headers = rdr.headers()?.clone();
+    drop(rdr);
 
     // Prepare output writer
     let mut wtr = csv::WriterBuilder::new()
@@ -934,35 +661,65 @@ fn merge_k_files(
         wtr.write_record(headers.iter())?;
     }
 
-    // Initialize heap with first record from each reader
-    let mut heap = BinaryHeap::new();
-    for (i, rdr) in readers.iter_mut().enumerate() {
-        if let Some(Ok(rec)) = rdr.records().next() {
-            heap.push(MergeRecord {
-                record: rec,
-                source_index: i,
-                sort_indices: Arc::clone(sort_indices),
-            });
-        }
+    // Determine sort indices
+    let sort_indices = Arc::clone(sort_indices);
+    if sort_indices.is_empty() {
+        warn!("No sort indices found, output will not be sorted");
     }
-    let mut record_counts = vec![0usize; readers.len()];
-    while let Some(MergeRecord {
-        record,
-        source_index,
-        ..
-    }) = heap.pop()
-    {
-        wtr.write_record(&record)?;
-        record_counts[source_index] += 1;
-        if let Some(Ok(next_rec)) = readers[source_index].records().next() {
-            heap.push(MergeRecord {
-                record: next_rec,
-                source_index,
-                sort_indices: Arc::clone(sort_indices),
-            });
+
+    // For large merges, do multi-pass k-way merge if chunk count > k
+    let mut current_chunks = files.to_vec();
+    let mut pass = 0;
+    let mut _temp_dirs = Vec::new(); // <-- keep temp dirs alive
+    while current_chunks.len() > 1 {
+        pass += 1;
+        let mut next_chunks = Vec::new();
+        let temp_dir = tempfile::tempdir()?;
+        _temp_dirs.push(temp_dir); // <-- keep temp_dir alive
+        let temp_dir_ref = _temp_dirs.last().unwrap();
+        let groups = current_chunks.chunks(2).enumerate();
+        info!(
+            "[merge] Merge pass {}: {} groups of up to {} files",
+            pass,
+            (current_chunks.len() + 1) / 2,
+            2
+        );
+
+        for (group_idx, group) in groups {
+            let out_path = temp_dir_ref
+                .path()
+                .join(format!("merge_pass{}_group{}.csv", pass, group_idx));
+            info!(
+                "[merge]   Group {}: merging {} files -> {:?}",
+                group_idx,
+                fmtnum(group.len()),
+                out_path
+            );
+            merge_k_files(group, &out_path, &headers, &sort_indices)?;
+            next_chunks.push(out_path);
         }
+        current_chunks = next_chunks;
+    }
+    // Final merge (or only pass if <= k)
+    let final_chunks = if current_chunks.is_empty() {
+        vec![]
+    } else {
+        current_chunks
+    };
+    if !final_chunks.is_empty() {
+        info!(
+            "[merge] Final merge: {} files -> {:?}",
+            fmtnum(final_chunks.len()),
+            output_path
+        );
+        merge_k_files(&final_chunks, output_path, &headers, &sort_indices)?;
     }
     wtr.flush()?;
+    info!(
+        "[merge] Merge complete: {:?} in {:.2?}",
+        output_path,
+        merge_start.elapsed()
+    );
     Ok(())
 }
 

--- a/src/parallel_merge/mtlog.rs
+++ b/src/parallel_merge/mtlog.rs
@@ -40,6 +40,14 @@ fn get_merge_buf_size() -> usize {
         .unwrap_or(8 * 1024 * 1024)
 }
 
+fn get_log_interval() -> usize {
+    std::env::var("MERGE_LOG_INTERVAL")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(500_000)
+}
+
 fn get_mtlog_field(line: &str, col: usize) -> String {
     // Adjust offsets as needed for your MTLogRecord
     const OFFSETS: &[(usize, usize)] = &[
@@ -96,9 +104,15 @@ pub fn merge_k_files_mtlog(
     sort_columns: &[MTLogSortColumn],
 ) -> Result<()> {
     let merge_timer = Instant::now();
-    info!("[mtlog] Starting k-way merge of {} files into {:?}", files.len().to_formatted_string(&Locale::en), output_path);
+    info!("[mtlog] [MERGE] Starting k-way merge of {} files into {:?}", files.len().to_formatted_string(&Locale::en), output_path);
     for (i, f) in files.iter().enumerate() {
-        debug!("[mtlog] Input file #{}: {}", i + 1, f.display());
+        if !f.exists() {
+            warn!("[mtlog] [MERGE] Input file #{}: {} (WARNING: does not exist)", i + 1, f.display());
+        } else if std::fs::metadata(f)?.len() == 0 {
+            warn!("[mtlog] [MERGE] Input file #{}: {} (WARNING: empty file)", i + 1, f.display());
+        } else {
+            debug!("[mtlog] [MERGE] Input file #{}: {}", i + 1, f.display());
+        }
     }
     let mut writer = BufWriter::with_capacity(get_merge_buf_size(), File::create(output_path)?);
     let mut readers: Vec<_> = files
@@ -114,14 +128,16 @@ pub fn merge_k_files_mtlog(
         }
     }
     let mut merged_count = 0usize;
-    let mut last_log = 0usize;
-    let log_interval = 500_000;
+    let mut last_log_group = 0usize;
+    let log_interval = get_log_interval();
     while let Some(MTLogHeapItem { line, idx, .. }) = heap.pop() {
         writeln!(writer, "{}", line)?;
         merged_count += 1;
-        if merged_count - last_log >= log_interval {
-            info!("[mtlog] Merged {} records so far...", merged_count.to_formatted_string(&Locale::en));
-            last_log = merged_count;
+        let current_group = merged_count / log_interval;
+        if current_group > last_log_group {
+            let elapsed = merge_timer.elapsed();
+            info!("[mtlog] [MERGE] Merged {} records so far... elapsed: {:.2?}", merged_count.to_formatted_string(&Locale::en), elapsed);
+            last_log_group = current_group;
         }
         let rdr = &mut readers[idx];
         let mut buf = String::new();
@@ -133,7 +149,7 @@ pub fn merge_k_files_mtlog(
     writer.flush()?;
     let elapsed = merge_timer.elapsed();
     let output_size = std::fs::metadata(output_path)?.len();
-    info!("[mtlog] Merge finished: {} records -> {:?} ({} bytes) in {:.2?}", merged_count.to_formatted_string(&Locale::en), output_path, output_size.to_formatted_string(&Locale::en), elapsed);
+    info!("[mtlog] [MERGE] Merge finished: {} records -> {:?} ({} bytes) in {:.2?}", merged_count.to_formatted_string(&Locale::en), output_path, output_size.to_formatted_string(&Locale::en), elapsed);
     // --- Validation: count lines in output ---
     let file = File::open(output_path)?;
     let reader = BufReader::new(file);
@@ -156,6 +172,12 @@ pub fn merge_k_files_mtlog(
     if sorted {
         info!("[mtlog][validate] Output is sorted correctly.");
     }
+    info!("[mtlog][SUMMARY] Merge summary: records={}, file_size={} bytes, elapsed={:.2?}, sorted={}",
+        merged_count.to_formatted_string(&Locale::en),
+        output_size.to_formatted_string(&Locale::en),
+        elapsed,
+        sorted
+    );
     Ok(())
 }
 
@@ -169,17 +191,21 @@ pub fn parallel_merge_sort_mtlog(
         warn!("[mtlog] No input files provided for MT log merge");
         return Err(anyhow::anyhow!("No input files provided"));
     }
-    info!("[mtlog] Starting parallel chunked merge of {} files into {:?}", input_paths.len().to_formatted_string(&Locale::en), output_path.as_ref());
+    info!("[mtlog] [CHUNK] Starting parallel chunked merge of {} files into {:?}", input_paths.len().to_formatted_string(&Locale::en), output_path.as_ref());
     let chunk_records = std::env::var("CHUNK_RECORDS").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(1_000_000);
-    info!("[mtlog] Chunk size: {} records", chunk_records.to_formatted_string(&Locale::en));
+    info!("[mtlog] [CHUNK] Chunk size: {} records", chunk_records.to_formatted_string(&Locale::en));
     let mut chunk_files: Vec<PathBuf> = Vec::new();
     let mut all_lines = Vec::new();
     let mut cur_records = 0;
     let chunk_timer = Instant::now();
     let mut total_records: usize = 0;
     let buf_size = get_merge_buf_size();
-    for path in input_paths {
-        info!("[mtlog] Reading input file: {}", path.display());
+    for (file_idx, path) in input_paths.iter().enumerate() {
+        info!("[mtlog] [CHUNK] Reading input file #{}: {}", file_idx + 1, path.display());
+        if !path.exists() {
+            warn!("[mtlog] [CHUNK] Input file {} does not exist!", path.display());
+            continue;
+        }
         let file = File::open(path)?;
         let reader = BufReader::with_capacity(buf_size, file);
         for line in reader.lines() {
@@ -188,11 +214,12 @@ pub fn parallel_merge_sort_mtlog(
             total_records += 1;
             all_lines.push(line);
             if cur_records >= chunk_records {
+                info!("[mtlog] [CHUNK] Sorting chunk of {} records...", all_lines.len().to_formatted_string(&Locale::en));
                 let mut chunk = std::mem::take(&mut all_lines);
                 cur_records = 0;
                 let sort_timer = Instant::now();
                 chunk.par_sort_unstable_by(|a, b| compare_mtlog_by_columns(a, b, sort_columns));
-                info!("[mtlog] Sorted chunk of {} records in {:.2?}", chunk.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
+                info!("[mtlog] [CHUNK] Sorted chunk of {} records in {:.2?}", chunk.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
                 let tmp = tempfile::NamedTempFile::new()?;
                 {
                     let mut writer = BufWriter::with_capacity(buf_size, tmp.as_file());
@@ -201,15 +228,16 @@ pub fn parallel_merge_sort_mtlog(
                 }
                 let chunk_path = tmp.path().to_path_buf();
                 tmp.persist(&chunk_path)?;
+                info!("[mtlog] [CHUNK] Wrote sorted chunk file #{} ({} records): {}", chunk_files.len() + 1, chunk.len().to_formatted_string(&Locale::en), chunk_path.display());
                 chunk_files.push(chunk_path);
-                info!("[mtlog] Wrote sorted chunk file #{} ({} records)", chunk_files.len().to_formatted_string(&Locale::en), chunk.len().to_formatted_string(&Locale::en));
             }
         }
     }
     if !all_lines.is_empty() {
+        info!("[mtlog] [CHUNK] Sorting final chunk of {} records...", all_lines.len().to_formatted_string(&Locale::en));
         let sort_timer = Instant::now();
         all_lines.par_sort_unstable_by(|a, b| compare_mtlog_by_columns(a, b, sort_columns));
-        info!("[mtlog] Sorted final chunk of {} records in {:.2?}", all_lines.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
+        info!("[mtlog] [CHUNK] Sorted final chunk of {} records in {:.2?}", all_lines.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
         let tmp = tempfile::NamedTempFile::new()?;
         {
             let mut writer = BufWriter::with_capacity(buf_size, tmp.as_file());
@@ -218,11 +246,11 @@ pub fn parallel_merge_sort_mtlog(
         }
         let chunk_path = tmp.path().to_path_buf();
         tmp.persist(&chunk_path)?;
+        info!("[mtlog] [CHUNK] Wrote sorted chunk file #{} ({} records): {}", chunk_files.len() + 1, all_lines.len().to_formatted_string(&Locale::en), chunk_path.display());
         chunk_files.push(chunk_path);
-        info!("[mtlog] Wrote sorted chunk file #{} ({} records)", chunk_files.len().to_formatted_string(&Locale::en), all_lines.len().to_formatted_string(&Locale::en));
     }
-    info!("[mtlog] {} sorted chunk files created in {:.2?}", chunk_files.len().to_formatted_string(&Locale::en), chunk_timer.elapsed());
-    info!("[mtlog] Total input records: {}", total_records.to_formatted_string(&Locale::en));
+    info!("[mtlog] [CHUNK] {} sorted chunk files created in {:.2?}", chunk_files.len().to_formatted_string(&Locale::en), chunk_timer.elapsed());
+    info!("[mtlog] [CHUNK] Total input records: {}", total_records.to_formatted_string(&Locale::en));
     let parallel_groups = get_merge_parallel_groups();
     if parallel_groups <= 1 || chunk_files.len() <= 2 {
         merge_k_files_mtlog(&chunk_files, output_path.as_ref(), sort_columns)?;
@@ -233,17 +261,24 @@ pub fn parallel_merge_sort_mtlog(
             .map(|c| c.to_vec())
             .collect();
         let temp_dir = tempfile::tempdir()?;
+        info!("[mtlog] [GROUP] Starting {} parallel group merges (group size: {})", group_chunks.len(), group_size);
         let group_outputs: Vec<PathBuf> = group_chunks
             .par_iter()
             .enumerate()
             .map(|(i, group)| {
                 let group_path = temp_dir.path().join(format!("group_merge_{}.mtlog", i));
-                merge_k_files_mtlog(group, &group_path, sort_columns)?;
+                info!("[mtlog] [GROUP] Merging group #{}/{} ({} files) into {}", i + 1, group_chunks.len(), group.len(), group_path.display());
+                let group_timer = Instant::now();
+                let result = merge_k_files_mtlog(group, &group_path, sort_columns);
+                info!("[mtlog] [GROUP] Finished group #{}/{} in {:.2?}", i + 1, group_chunks.len(), group_timer.elapsed());
+                result?;
                 Ok(group_path)
             })
             .collect::<Result<Vec<_>>>()?;
+        info!("[mtlog] [GROUP] All group merges complete. Merging group outputs into final output...");
         merge_k_files_mtlog(&group_outputs, output_path.as_ref(), sort_columns)?;
     }
-    info!("[mtlog] Merge complete: chunked+sorted into {:?}", output_path.as_ref());
+    let total_elapsed = total_timer.elapsed();
+    info!("[mtlog] [SUMMARY] Parallel merge complete: output={:?}, elapsed={:.2?}", output_path.as_ref(), total_elapsed);
     Ok(())
 }

--- a/src/parallel_merge/mtlog.rs
+++ b/src/parallel_merge/mtlog.rs
@@ -1,0 +1,249 @@
+// --- MTLog Parallel Merge Implementation ---
+
+use anyhow::Result;
+use log::{debug, error, info, warn};
+use num_format::{Locale, ToFormattedString};
+use rayon::prelude::*;
+use std::cmp::Ordering;
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MTLogSortType {
+    Date,
+    Time,
+    Num,
+    Str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MTLogSortColumn {
+    pub index: usize,
+    pub col_type: MTLogSortType,
+}
+
+fn get_merge_parallel_groups() -> usize {
+    std::env::var("MERGE_PARALLEL_GROUPS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v >= 1)
+        .unwrap_or(1)
+}
+
+fn get_merge_buf_size() -> usize {
+    std::env::var("MERGE_BUF_MB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|mb| mb * 1024 * 1024)
+        .unwrap_or(8 * 1024 * 1024)
+}
+
+fn get_mtlog_field(line: &str, col: usize) -> String {
+    // Adjust offsets as needed for your MTLogRecord
+    const OFFSETS: &[(usize, usize)] = &[
+        (0,8), (8,6), (14,7), (21,4), (25,1), (26,8), (34,1), (35,1)
+    ];
+    if col >= OFFSETS.len() {
+        return String::new();
+    }
+    let (start, len) = OFFSETS[col];
+    line.get(start..start+len).unwrap_or("").trim().to_string()
+}
+
+fn compare_mtlog_by_columns(a: &str, b: &str, sort_columns: &[MTLogSortColumn]) -> Ordering {
+    for col in sort_columns {
+        let (v1, v2) = (get_mtlog_field(a, col.index), get_mtlog_field(b, col.index));
+        let ord = match col.col_type {
+            MTLogSortType::Date | MTLogSortType::Time => v1.cmp(&v2),
+            MTLogSortType::Num => v1.parse::<u64>().unwrap_or(0).cmp(&v2.parse::<u64>().unwrap_or(0)),
+            MTLogSortType::Str => v1.cmp(&v2),
+        };
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    Ordering::Equal
+}
+
+#[derive(Eq)]
+struct MTLogHeapItem<'a> {
+    line: String,
+    idx: usize,
+    sort_columns: &'a [MTLogSortColumn],
+}
+
+impl<'a> Ord for MTLogHeapItem<'a> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        compare_mtlog_by_columns(&other.line, &self.line, self.sort_columns)
+    }
+}
+impl<'a> PartialOrd for MTLogHeapItem<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<'a> PartialEq for MTLogHeapItem<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.line == other.line
+    }
+}
+
+pub fn merge_k_files_mtlog(
+    files: &[PathBuf],
+    output_path: &Path,
+    sort_columns: &[MTLogSortColumn],
+) -> Result<()> {
+    let merge_timer = Instant::now();
+    info!("[mtlog] Starting k-way merge of {} files into {:?}", files.len().to_formatted_string(&Locale::en), output_path);
+    for (i, f) in files.iter().enumerate() {
+        debug!("[mtlog] Input file #{}: {}", i + 1, f.display());
+    }
+    let mut writer = BufWriter::with_capacity(get_merge_buf_size(), File::create(output_path)?);
+    let mut readers: Vec<_> = files
+        .iter()
+        .map(|f| BufReader::with_capacity(get_merge_buf_size(), File::open(f).expect("Failed to open chunk file")))
+        .collect();
+    let mut heap = std::collections::BinaryHeap::new();
+    for (idx, rdr) in readers.iter_mut().enumerate() {
+        let mut buf = String::new();
+        if rdr.read_line(&mut buf)? > 0 {
+            let line = buf.trim_end_matches('\n').to_string();
+            heap.push(MTLogHeapItem { line, idx, sort_columns });
+        }
+    }
+    let mut merged_count = 0usize;
+    let mut last_log = 0usize;
+    let log_interval = 500_000;
+    while let Some(MTLogHeapItem { line, idx, .. }) = heap.pop() {
+        writeln!(writer, "{}", line)?;
+        merged_count += 1;
+        if merged_count - last_log >= log_interval {
+            info!("[mtlog] Merged {} records so far...", merged_count.to_formatted_string(&Locale::en));
+            last_log = merged_count;
+        }
+        let rdr = &mut readers[idx];
+        let mut buf = String::new();
+        if rdr.read_line(&mut buf)? > 0 {
+            let next_line = buf.trim_end_matches('\n').to_string();
+            heap.push(MTLogHeapItem { line: next_line, idx, sort_columns });
+        }
+    }
+    writer.flush()?;
+    let elapsed = merge_timer.elapsed();
+    let output_size = std::fs::metadata(output_path)?.len();
+    info!("[mtlog] Merge finished: {} records -> {:?} ({} bytes) in {:.2?}", merged_count.to_formatted_string(&Locale::en), output_path, output_size.to_formatted_string(&Locale::en), elapsed);
+    // --- Validation: count lines in output ---
+    let file = File::open(output_path)?;
+    let reader = BufReader::new(file);
+    let mut line_count = 0usize;
+    let mut prev_line: Option<String> = None;
+    let mut sorted = true;
+    for line in reader.lines() {
+        let line = line?;
+        if let Some(prev) = &prev_line {
+            if compare_mtlog_by_columns(prev, &line, sort_columns) == Ordering::Greater {
+                error!("[mtlog][validate] Output is NOT sorted at line {}!", line_count + 1);
+                sorted = false;
+                break;
+            }
+        }
+        prev_line = Some(line.clone());
+        line_count += 1;
+    }
+    info!("[mtlog][validate] Output line count: {}", line_count.to_formatted_string(&Locale::en));
+    if sorted {
+        info!("[mtlog][validate] Output is sorted correctly.");
+    }
+    Ok(())
+}
+
+pub fn parallel_merge_sort_mtlog(
+    input_paths: &[PathBuf],
+    output_path: impl AsRef<Path>,
+    sort_columns: &[MTLogSortColumn],
+) -> Result<()> {
+    let total_timer = Instant::now();
+    if input_paths.is_empty() {
+        warn!("[mtlog] No input files provided for MT log merge");
+        return Err(anyhow::anyhow!("No input files provided"));
+    }
+    info!("[mtlog] Starting parallel chunked merge of {} files into {:?}", input_paths.len().to_formatted_string(&Locale::en), output_path.as_ref());
+    let chunk_records = std::env::var("CHUNK_RECORDS").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(1_000_000);
+    info!("[mtlog] Chunk size: {} records", chunk_records.to_formatted_string(&Locale::en));
+    let mut chunk_files: Vec<PathBuf> = Vec::new();
+    let mut all_lines = Vec::new();
+    let mut cur_records = 0;
+    let chunk_timer = Instant::now();
+    let mut total_records: usize = 0;
+    let buf_size = get_merge_buf_size();
+    for path in input_paths {
+        info!("[mtlog] Reading input file: {}", path.display());
+        let file = File::open(path)?;
+        let reader = BufReader::with_capacity(buf_size, file);
+        for line in reader.lines() {
+            let line = line?;
+            cur_records += 1;
+            total_records += 1;
+            all_lines.push(line);
+            if cur_records >= chunk_records {
+                let mut chunk = std::mem::take(&mut all_lines);
+                cur_records = 0;
+                let sort_timer = Instant::now();
+                chunk.par_sort_unstable_by(|a, b| compare_mtlog_by_columns(a, b, sort_columns));
+                info!("[mtlog] Sorted chunk of {} records in {:.2?}", chunk.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
+                let tmp = tempfile::NamedTempFile::new()?;
+                {
+                    let mut writer = BufWriter::with_capacity(buf_size, tmp.as_file());
+                    for l in &chunk { writeln!(writer, "{}", l)?; }
+                    writer.flush()?;
+                }
+                let chunk_path = tmp.path().to_path_buf();
+                tmp.persist(&chunk_path)?;
+                chunk_files.push(chunk_path);
+                info!("[mtlog] Wrote sorted chunk file #{} ({} records)", chunk_files.len().to_formatted_string(&Locale::en), chunk.len().to_formatted_string(&Locale::en));
+            }
+        }
+    }
+    if !all_lines.is_empty() {
+        let sort_timer = Instant::now();
+        all_lines.par_sort_unstable_by(|a, b| compare_mtlog_by_columns(a, b, sort_columns));
+        info!("[mtlog] Sorted final chunk of {} records in {:.2?}", all_lines.len().to_formatted_string(&Locale::en), sort_timer.elapsed());
+        let tmp = tempfile::NamedTempFile::new()?;
+        {
+            let mut writer = BufWriter::with_capacity(buf_size, tmp.as_file());
+            for l in &all_lines { writeln!(writer, "{}", l)?; }
+            writer.flush()?;
+        }
+        let chunk_path = tmp.path().to_path_buf();
+        tmp.persist(&chunk_path)?;
+        chunk_files.push(chunk_path);
+        info!("[mtlog] Wrote sorted chunk file #{} ({} records)", chunk_files.len().to_formatted_string(&Locale::en), all_lines.len().to_formatted_string(&Locale::en));
+    }
+    info!("[mtlog] {} sorted chunk files created in {:.2?}", chunk_files.len().to_formatted_string(&Locale::en), chunk_timer.elapsed());
+    info!("[mtlog] Total input records: {}", total_records.to_formatted_string(&Locale::en));
+    let parallel_groups = get_merge_parallel_groups();
+    if parallel_groups <= 1 || chunk_files.len() <= 2 {
+        merge_k_files_mtlog(&chunk_files, output_path.as_ref(), sort_columns)?;
+    } else {
+        let group_size = (chunk_files.len() + parallel_groups - 1) / parallel_groups;
+        let group_chunks: Vec<Vec<PathBuf>> = chunk_files
+            .chunks(group_size)
+            .map(|c| c.to_vec())
+            .collect();
+        let temp_dir = tempfile::tempdir()?;
+        let group_outputs: Vec<PathBuf> = group_chunks
+            .par_iter()
+            .enumerate()
+            .map(|(i, group)| {
+                let group_path = temp_dir.path().join(format!("group_merge_{}.mtlog", i));
+                merge_k_files_mtlog(group, &group_path, sort_columns)?;
+                Ok(group_path)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        merge_k_files_mtlog(&group_outputs, output_path.as_ref(), sort_columns)?;
+    }
+    info!("[mtlog] Merge complete: chunked+sorted into {:?}", output_path.as_ref());
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces a significant update to the `MTLog` processing system, including the addition of a parallel merge implementation for MTLog files and adjustments to the mockup script. The changes optimize file handling, sorting, and merging processes to improve scalability and performance.

### Mockup script adjustment:

* [`run_mtlog_mockup.sh`](diffhunk://#diff-e78c62ddd3ea95c4c00d3a2510baeb924575707210003667dabb50e41856fc41L1-R1): Reduced the number of records generated from `10,000,000` to `1,000,000` for testing purposes, likely to improve runtime efficiency during mockup execution.

### MTLog parallel merge implementation:

* `src/parallel_merge/mtlog.rs`: Added a comprehensive parallel merge implementation for MTLog files, including:
  - Support for custom sorting by columns and types (`MTLogSortType` and `MTLogSortColumn` enums).
  - Functions for environment-based configuration (e.g., buffer size, parallel groups, log intervals).
  - Efficient chunk-based sorting using `rayon` for parallelism.
  - Validation of output file sorting and detailed logging for merge operations.